### PR TITLE
feat: add email ses stack to sandbox 01 account

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -92,6 +92,11 @@ export const configurations: { [key: string]: Configuration } = {
         emailDomain: 'nijmegen.nl',
         emailFromDomain: 'amazonses.nijmegen.nl',
       },
+      {
+        name: 'sandbox-01-nijmegen',
+        accountEnvironment: Statics.gnSandbox01Environment,
+        isAccountDomain: true,
+      },
     ],
   },
 };

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -13,6 +13,8 @@ export class Statics {
   static readonly AWS_ACCOUNT_WEBFORMS_ACCP = '338472043295';
   static readonly AWS_ACCOUNT_WEBFORMS_PROD = '147064197580';
 
+  static readonly AWS_ACCOUNT_SANDBOX_01 = '833119272131';
+
   // Pipelien values
   static readonly gnBuildCodeStarConnectionArn = 'arn:aws:codestar-connections:eu-central-1:836443378780:connection/9d20671d-91bc-49e2-8680-59ff96e2ab11';
 
@@ -43,5 +45,9 @@ export class Statics {
     region: 'eu-central-1',
   };
 
+  static readonly gnSandbox01Environment = {
+    account: Statics.AWS_ACCOUNT_SANDBOX_01,
+    region: 'eu-central-1',
+  };
 
 }


### PR DESCRIPTION
- adds ses stack to sandbox01 with its own domain http://sandbox-01.csp-nijmegen.nl/
- goal to add email settings to open forms container