### PR TITLE
feat: added submission sotrage dev acc and prod to mail csv and alert…

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -107,6 +107,21 @@ export const configurations: { [key: string]: Configuration } = {
         accountEnvironment: Statics.gnSocialeRechercheProd,
         isAccountDomain: true,
       },
+      {
+        name: 'submission-storage-dev',
+        accountEnvironment: Statics.gnSubmissionStorageDev,
+        isAccountDomain: true,
+      },
+      {
+        name: 'submission-storage-accp',
+        accountEnvironment: Statics.gnSubmissionStorageAccp,
+        isAccountDomain: true,
+      },
+      {
+        name: 'submission-storage-prod',
+        accountEnvironment: Statics.gnSubmissionStorageProd,
+        isAccountDomain: true,
+      },
     ],
   },
 };

--- a/src/Statics.ts
+++ b/src/Statics.ts
@@ -15,6 +15,9 @@ export class Statics {
   static readonly AWS_ACCOUNT_SANDBOX_01 = '833119272131';
   static readonly AWS_ACCOUNT_SOCIALE_RECHERCHE_ACCP = '543802458112';
   static readonly AWS_ACCOUNT_SOCIALE_RECHERCHE_PROD = '958875843009';
+  static readonly AWS_ACCOUNT_SUBMISSION_STORAGE_DEV = '358927146986';
+  static readonly AWS_ACCOUNT_SUBMISSION_STORAGE_ACCP = '654654253219';
+  static readonly AWS_ACCOUNT_SUBMISSION_STORAGE_PROD = '606343885688';
 
   // Pipelien values
   static readonly gnBuildCodeStarConnectionArn = 'arn:aws:codestar-connections:eu-central-1:836443378780:connection/9d20671d-91bc-49e2-8680-59ff96e2ab11';
@@ -58,6 +61,21 @@ export class Statics {
 
   static readonly gnSocialeRechercheProd = {
     account: Statics.AWS_ACCOUNT_SOCIALE_RECHERCHE_PROD,
+    region: 'eu-central-1',
+  };
+
+  static readonly gnSubmissionStorageDev = {
+    account: Statics.AWS_ACCOUNT_SUBMISSION_STORAGE_DEV,
+    region: 'eu-central-1',
+  };
+
+  static readonly gnSubmissionStorageAccp = {
+    account: Statics.AWS_ACCOUNT_SUBMISSION_STORAGE_ACCP,
+    region: 'eu-central-1',
+  };
+
+  static readonly gnSubmissionStorageProd = {
+    account: Statics.AWS_ACCOUNT_SUBMISSION_STORAGE_PROD,
     region: 'eu-central-1',
   };
 


### PR DESCRIPTION
ses-management basic setup for all submission storage accounts
dev is used most often right now, hence also dev. Maybe remove in the future.
Needed to mail lists to PO and for sports overviews.
